### PR TITLE
未ログイン用のリダイレクト設定をブックマークアクションに追加

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,4 +1,5 @@
 class ShopsController < ApplicationController
+  before_action :authenticate_user!, only: [ :bookmarks ]
   before_action :set_ransack_query, only: [ :index ]
 
   def index;end


### PR DESCRIPTION
## 概要
未ログインユーザーがお気に入りページにアクセスした際、ログイン画面にリダイレクトする設定を追加しました。