### PR TITLE
ショップ詳細ページにお気に入りボタン・外部リンク用のアイコンを追加

### DIFF
--- a/app/views/shops/_bookmark.html.erb
+++ b/app/views/shops/_bookmark.html.erb
@@ -3,8 +3,8 @@
             method: :post,
             data: { turbo_method: :post },
             class: "flex items-center" do %>
-  <button class="flex justify-center items-center w-11 h-11 sm:w-9 sm:h-9 border opacity-90 rounded-full bg-gray-50 hoverable:hover:text-red-500 transition-colors text-gray-400">
-    <span class="material-symbols-outlined material-icons md-30 material-symbols-outlined-bookmark">
+  <button class="flex justify-center items-center w-10 h-10 md:w-9 md:h-9 border opacity-90 rounded-full bg-gray-50 hoverable:hover:text-red-500 transition-colors text-gray-400">
+    <span class="material-symbols-outlined material-icons md-30 material-symbols-outlined-bookmark" style="font-size:28px;">
       favorite
     </span>
   </button>

--- a/app/views/shops/_unbookmark.html.erb
+++ b/app/views/shops/_unbookmark.html.erb
@@ -3,8 +3,8 @@
             method: :delete,
             data: { turbo_method: :delete },
             class: "flex items-center" do %>
-  <button class="flex justify-center items-center w-11 h-11 sm:w-9 sm:h-9 border opacity-90 rounded-full bg-gray-50 text-red-500">
-    <span class="material-symbols-outlined material-symbols-outlined-unbookmark material-icons md-30">
+  <button class="flex justify-center items-center w-10 h-10 md:w-9 md:h-9 border opacity-90 rounded-full bg-gray-50 text-red-500">
+    <span class="material-symbols-outlined material-symbols-outlined-unbookmark material-icons md-30" style="font-size:28px;">
       favorite
     </span>
   </button>

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-[1200px] mx-auto mb-20">
-  <h2 class="text-2xl md:text-3xl font-bold mt-6 mb-1 ml-2 md:ml-0"><%= @shop.name %></h2>
+  <h2 class="text-xl md:text-3xl font-bold mt-6 mb-1 ml-2 md:ml-0"><%= @shop.name %></h2>
 
   <div class="flex mb-2 ml-2 md:ml-0">
     <div class="flex items-center mr-3">
@@ -72,9 +72,9 @@
         <p class="text-base font-bold w-full md:w-40 flex mb-2 md:mb-0 items-center">
           <span class="material-symbols-outlined mr-2">desktop_windows</span> 公式サイト
         </p>
-        <div class="flex items-end">
-        <%= link_to @shop.web_site.to_s, @shop.web_site.to_s, class: "border-b pb-0.5 border-gray-700 text-base w-full md:w-auto ", target: :_blank, rel: "noopener noreferrer" %>
-        <span class="material-symbols-outlined ml-1"> open_in_new </span>
+        <div class="inline-flex items-end">
+        <%= link_to @shop.web_site.to_s, @shop.web_site.to_s, class: "border-b pb-0.5 border-gray-700 text-base w-full md:w-auto  w-auto", target: :_blank, rel: "noopener noreferrer" %>
+        <span class="material-symbols-outlined ml-1" style="font-size:19px;"> open_in_new </span>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## 概要
詳細ページにアイコンとお気に入りボタンを追加しました。

## 内容
- 外部リンクや新規タブを開くリンクにはアイコンを設置
- フォントサイズ・お気に入りボタンのサイズ調整