### PR TITLE
プライバシーポリシーページの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,5 @@
 class StaticPagesController < ApplicationController
   def home; end
+
+  def privacy; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,10 +1,11 @@
 <footer id="footer" class="bg-baseColor text-gray-600 py-4 shadow-custom">
   <div class="container mx-auto">
-    <div class="flex flex-col sm:flex-row justify-between">
-      <div class="w-full sm:w-1/2">
-        <div class="text-center sm:text-left text-sm">
-          <p>© 2024. FragranceMe</p>
-        </div>
+    <div class="flex flex-col sm:flex-row justify-between items-center">
+      <div class="w-full sm:w-1/2 text-center sm:text-left text-sm">
+        <p>© 2024. FragranceMe</p>
+      </div>
+      <div class="w-full mt-1 md:mt-0 sm:w-auto text-sm text-center sm:text-right">
+        <%= link_to "プライバシーポリシー", privacy_policy_path %>
       </div>
     </div>
   </div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,69 @@
+<div class="w-11/12 md:max-w-screen-xl mx-auto mb-20 p-4 py-10 md:py-11 md:px-8 mt-12 rounded-md bg-baseColor shadow-custom">
+
+    <h1 class="font-bold text-2xl mb-4">プライバシーポリシー</h1>
+    <p class="text-sm mb-6 leading-7 text-gray-700">FragranceMe.com（以下，「当社」といいます。）は，本ウェブサイト上で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。</p>
+
+    <div class="mb-6">
+      <h2 class="font-bold text-lg mb-2">お客様から取得する情報</h2>
+      <p class="text-sm text-gray-700 mb-2">当社は、お客様から以下の情報を取得します。</p>
+      <ul class="list-disc leading-8 pl-8 text-sm text-gray-700">
+        <li>氏名(ニックネームやペンネームも含む)</li>
+        <li>メールアドレス</li>
+        <li>写真や動画</li>
+        <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+        <li>Cookie(クッキー)を用いて生成された識別情報</li>
+        <li>OSが生成するID、端末の種類、端末識別子等のお客様が利用するOSや端末に関する情報</li>
+        <li>当社ウェブサイトの滞在時間、入力履歴、購買履歴等の当社ウェブサイトにおけるお客様の行動履歴</li>
+        <li>当社アプリの起動時間、入力履歴、購買履歴等の当社アプリの利用履歴</li>
+      </ul>
+    </div>
+
+    <div class="mb-6">
+      <h2 class="font-bold text-lg mb-2">お客様の情報を利用する目的</h2>
+      <p class="text-sm text-gray-700 mb-2">当社は、お客様から取得した情報を、以下の目的のために利用します。</p>
+      <ul class="list-disc leading-8 pl-8 text-sm text-gray-700">
+        <li>当社サービスに関する登録の受付、お客様の本人確認、認証のため
+        <li>お客様の当社サービスの利用履歴を管理するため
+        <li>利用料金の決済のため
+        <li>当社サービスにおけるお客様の行動履歴を分析し、当社サービスの維持改善に役立てるため
+        <li>当社のサービスに関するご案内をするため
+        <li>お客様からのお問い合わせに対応するため
+        <li>当社の規約や法令に違反する行為に対応するため
+        <li>当社サービスの変更、提供中止、終了、契約解除をご連絡するため
+        <li>当社規約の変更等を通知するため
+        <li>以上の他、当社サービスの提供、維持、保護及び改善のため
+      </ul>
+    </div>
+
+    <div class="mb-6">
+      <h2 class="font-bold text-lg mb-2">安全管理のために講じた措置</h2>
+      <p class="text-sm text-gray-700 mb-2 leading-7">当社が、お客様から取得した情報に関して安全管理のために講じた措置につきましては、末尾記載のお問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+    </div>
+
+    <div class="mb-6">
+      <h2 class="font-bold text-lg mb-2">第三者提供</h2>
+      <p class="text-sm text-gray-700 leading-7">当社は、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
+      <p class="text-sm text-gray-700  leading-7 mb-2">但し、次の場合は除きます。</p>
+      <ul class="list-disc leading-8 pl-8 text-sm text-gray-700">
+        <li>個人データの取扱いを外部に委託する場合
+        <li>当社や当社サービスが買収された場合
+        <li>事業パートナーと共同利用する場合（具体的な共同利用がある場合は、その内容を別途公表します。）
+        <li>その他、法律によって合法的に第三者提供が許されている場合
+      </ul>
+    </div>
+
+    <div class="mb-6">
+      <h2 class="font-bold text-lg mb-2">プライバシーポリシーの変更</h2>
+      <p class="text-sm text-gray-700 leading-7">当社は、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+    </div>
+
+    <div class="mb-8">
+      <h2 class="font-bold text-lg mb-2">お問い合わせ</h2>
+      <p class="text-sm text-gray-700">お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、以下のメールアドレスよりご連絡ください。</p>
+      <p class="link text-sm text-blue-600">fragrance-me@gmail.com</p>
+    </div>
+
+    <div class="flex justify-end">
+      <p class="text-sm text-gray-700">2025年1月22日 制定</p>
+    </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get "privacy", to: "static_pages#privacy", as: "privacy_policy"
+
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 概要
プライバシーポリシーのページを作成しました。

## 内容
- プライバシーポリシー用のルーティング、コントローラー、ビューを作成
- フッターにプライバシーポリシーのリンクを追加