### PR TITLE
アプリ機能説明の画像順序を修正

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -22,13 +22,13 @@
         <div class="p-6 flex flex-col items-center w-full md:w-1/3">
           <h3 class="text-lg md:text-xl text-center font-medium text-main">ショップ検索</h3>
           <p class="text-gray-700">キーワードや検索条件から、あなたの気になるショップを簡単に見つけることができます！</p>
-          <%= image_tag "mock_iphone02.png", class: "h-auto w-full object-cover mt-4" %>
+          <%= image_tag "mock_iphone01.png", class: "h-auto w-full object-cover mt-4" %>
         </div>
 
         <div class="p-6 flex flex-col items-center w-full md:w-1/3">
           <h3 class="text-lg md:text-xl  text-center font-medium text-main">現在地から探す</h3>
           <p class="text-base text-gray-700">近くのショップをすぐに見つけることができるため、外出時の隙間時間にも手軽にショップを探せます！</p>
-          <%= image_tag "mock_iphone01.png", class: "h-auto w-full object-cover mt-4" %>
+          <%= image_tag "mock_iphone02.png", class: "h-auto w-full object-cover mt-4" %>
         </div>
 
         <div class="p-6 flex flex-col items-center w-full md:w-1/3">


### PR DESCRIPTION
## 概要
「ショップ検索」と「現在地から探す」機能の説明に対して画像の並びが間違えていたため、修正しました。