### PR TITLE
Userのモデルスペックを作成 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ public/assets/*
 /vendor/bundle
 
 /config/credentials/development.key
+
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,8 @@ group :development, :test do
   gem "rspec-rails"
   gem "factory_bot_rails"
   gem "faker"
+
+  gem "simplecov"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
       devise (>= 4.9.0)
     devise-i18n-views (0.3.7)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     dotenv (3.1.4)
     dotenv-rails (3.1.4)
       dotenv (= 3.1.4)
@@ -394,6 +395,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
@@ -477,6 +484,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "バリデーションのテスト" do
+    it 'ユーザーネーム、メールアドレス、パスワードがあれば有効であること' do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+
+    it 'メールアドレスが一意であること' do
+      user1 = create(:user)
+      user2 = build(:user)
+      user2.email = user1.email
+      user2.valid?
+      expect(user2.errors[:email]).to include('はすでに存在します')
+    end
+
+    it 'ユーザーネーム、メールアドレス、パスワードは必須項目であること' do
+      user = build(:user, name: nil, email: nil, password: nil)
+      user.valid?
+      expect(user.errors[:name]).to include('を入力してください')
+      expect(user.errors[:email]).to include('を入力してください')
+      expect(user.errors[:password]).to include('を入力してください')
+    end
+
+    it 'ユーザーネームは50文字以下であること' do
+      user = build(:user, name: 'a' * 100)
+      user.valid?
+      expect(user.errors[:name]).to include('は50文字以内で入力してください')
+    end
+
+    it 'パスワードの長さが6文字以上であること' do
+      user = build(:user, password: 123)
+      user.valid?
+      expect(user.errors[:password]).to include('は6文字以上で入力してください')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,14 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+
+require 'simplecov'
+SimpleCov.start do
+  if ENV['CIRCLE_ARTIFACTS']
+    dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')
+    SimpleCov.coverage_dir(dir)
+  end
+end
+
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
## 概要
ユーザー登録機能のモデルスペックを作成

## 内容
- Userモデルのバリデーションテストを追加
- gem "simplecov"を導入しカバレッジを計測
- gitignoreに/coverageを追加