### PR TITLE
口コミの編集機能を追加

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,17 +1,42 @@
 class ReviewsController < ApplicationController
+  before_action :set_review, only: %i[edit update destroy]
+
   def create
     @review = current_user.reviews.build(review_params)
     @review.save
   end
 
+  def edit
+    @shop = @review.shop
+  end
+
+  def update
+    @shop = @review.shop
+    @review = Review.find(params[:id])
+
+    if @review.update(update_review_params)
+      flash[:notice] = "口コミを更新しました。"
+      redirect_to shop_path(@shop)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   def destroy
-    @review = current_user.reviews.find(params[:id])
     @review.destroy!
   end
 
   private
 
+  def set_review
+    @review = current_user.reviews.find(params[:id])
+  end
+
   def review_params
     params.require(:review).permit(:body).merge(shop_id: params[:shop_id])
+  end
+
+  def update_review_params
+    params.require(:review).permit(:body)
   end
 end

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -4,6 +4,7 @@
   <p class="mt-2 text-gray-800"><%= review.body %></p>
 
   <% if current_user&.own?(review) %>
-    <%= link_to "口コミを削除する", review_path(review), class: "bg-white mt-2 p-1 border inline-block text-xs", data: { turbo_method: :delete, turbo_confirm: "口コミを削除すると元に戻せません。\n本当に削除しますか？" } %>
+    <%= link_to "口コミを編集する", edit_review_path(review), class: "bg-white mt-2 p-1 border inline-block text-xs mr-3 hover:text-main transition duration-400" %>
+    <%= link_to "口コミを削除する", review_path(review), class: "bg-white mt-2 p-1 border inline-block text-xs hover:text-main transition duration-400", data: { turbo_method: :delete, turbo_confirm: "口コミを削除すると元に戻せません。\n本当に削除しますか？" } %>
   <% end %>
 </div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,16 @@
+<div class="p-5" id="review-form">
+  <div class="w-full max-w-lg mx-auto">
+     <h2 class="text-xl md:text-2xl font-bold mb-4">口コミの編集（<%= @shop.name %>）</h2>
+    <%= form_with model: @review, url: review_path(@review) do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+      <div class="mb-2">
+        <%= f.label :body, class: "block text-gray-700" %>
+        <%= f.text_area :body, class: "form-control mt-1 block w-full border rounded-md shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50 p-2", rows: "4" %>
+      </div>
+
+      <div class="flex justify-center">
+        <%= f.submit "口コミを更新する", class: "cursor-pointer mt-1 bg-main px-10 py-3 text-white rounded hover:bg-opacity-90 transition duration-200 shadow" %>
+      </div>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
口コミの編集機能を追加しました。

## 内容
- 投稿者の場合のみ、編集画面への動線を追加
- 口コミの更新後は「口コミを更新しました。」というフラッシュメッセージと共に投稿したショップ詳細へ遷移