### PR TITLE
ショップ検索のオートコンプリート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", "~> 7.0.0", require: false
+  gem "brakeman", "~> 7.0.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -452,7 +452,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman (~> 7.0.0)
+  brakeman (~> 7.0.2)
   capybara
   cssbundling-rails
   debug

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -49,7 +49,7 @@ class ShopsController < ApplicationController
     query = params[:q]
     shops = Shop.where("name LIKE ?", "%#{query}%").select(:name).distinct.limit(5)
 
-    render json: shops.map { |shop| {id: nil, name: shop.name} }
+    render json: shops.map { |shop| { id: nil, name: shop.name } }
   end
 
 

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -99,7 +99,7 @@ class ShopsController < ApplicationController
   end
 
   def paginate_shops(shops)
-    shops.page(params[:page]).per(1)
+    shops.page(params[:page]).per(12)
   end
 
   def generate_shops_json(shops)

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -45,6 +45,13 @@ class ShopsController < ApplicationController
     @shop_bookmarks = current_user.shop_bookmarks.includes(:shop).order(created_at: :desc)
   end
 
+  def autocomplete
+    query = params[:q]
+    shops = Shop.where("name LIKE ?", "%#{query}%").select(:name).distinct.limit(5)
+
+    render json: shops.map { |shop| {id: nil, name: shop.name} }
+  end
+
 
   private
 
@@ -92,7 +99,7 @@ class ShopsController < ApplicationController
   end
 
   def paginate_shops(shops)
-    shops.page(params[:page]).per(12)
+    shops.page(params[:page]).per(1)
   end
 
   def generate_shops_json(shops)

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -2,7 +2,38 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="autocomplete"
 export default class extends Controller {
+  static values = { url: String }
+  static targets = ["input", "results"]
+
   connect() {
+    if (!this.hasInputTarget) return;
+    this.inputTarget.addEventListener("input", this.search.bind(this));
   }
 
+async search() {
+
+  const query = this.inputTarget.value.trim();
+
+  if (query.length < 2){
+    this.resultsTarget.innerHTML = "";
+    return;
+  }
+
+  try {
+    const response = await fetch(`${this.urlValue}?q=${encodeURIComponent(query)}`)
+    const items = await response.json();
+
+    this.resultsTarget.innerHTML = items.map(item =>
+      `<li class="cursor-pointer hover:bg-gray-100 p-2" data-action="click->autocomplete#select" data-id="${item.id}">${item.name}</li>`
+    ).join("");
+
+  } catch (error) {
+    console.error("search中にエラーが発生しました", error);
+  }
+}
+
+select(event) {
+  this.inputTarget.value = event.currentTarget.textContent;
+  this.resultsTarget.innerHTML = "";
+}
 }

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="autocomplete"
+export default class extends Controller {
+  connect() {
+  }
+
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import AutocompleteController from "./autocomplete_controller"
+application.register("autocomplete", AutocompleteController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/shops/_search_form.html.erb
+++ b/app/views/shops/_search_form.html.erb
@@ -1,6 +1,14 @@
 <%= search_form_for @q, url: shops_path, method: :get, data: { turbo_frame: "search_results" }, html: { class: "bg-gray-50 rounded-md border border-gray-300 shadow-sm flex items-center p-1 w-full shadow-sm" } do |f| %>
-  <span class="material-symbols-outlined text-gray-400 mx-1" style="font-variation-settings: 'FILL' 1;" >search</span>
-  <%= f.text_field :name_or_address_cont, placeholder: "ショップ名や住所から探す", class: "w-full outline-none bg-gray-50 autofill:bg-transparent text-sm autofill:shadow-[inset_0_0_0px_1000px_theme(colors.gray.50)]" %>
 
-  <%= f.submit "検索", class: "bg-main text-white text-center text-sm rounded-md p-2 w-20 my-btn cursor-pointer" %>
+  <div data-controller="autocomplete" data-autocomplete-url-value="<%= autocomplete_shops_path %>" class="relative w-full" role="combobox">
+    <div class="flex items-center w-full">
+      <span class="material-symbols-outlined text-gray-400 mx-1" style="font-variation-settings: 'FILL' 1;">search</span>
+      <%= f.search_field :name_or_address_cont, placeholder: "ショップ名や住所から探す", class: "w-full outline-none bg-gray-50 autofill:bg-transparent text-sm autofill:shadow-[inset_0_0_0px_1000px_theme(colors.gray.50)]", data: { "autocomplete-target": "input" } %>
+      <%= f.submit "検索", class: "bg-main text-white text-center text-sm rounded-md p-2 w-20 my-btn cursor-pointer" %>
+    </div>
+
+    <%= f.hidden_field :name, data: { "autocomplete_target": "hidden" } %>
+
+    <ul data-autocomplete-target="results" class="absolute left-0 right-0 bg-white rounded-md shadow-lg mt-2 max-h-60 overflow-auto z-50"></ul>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       get "map"
       get "list"
       get "bookmarks"
+      get "autocomplete"
     end
   end
 


### PR DESCRIPTION
## 概要
Stimulusにてオートコンプリート機能を実装しました。

## 内容
**Stimulusコントローラーを生成**
`bin/rails g stimulus autocomplete`

**検索用のルーティング設定**
`get "autocomplete"`


**コントローラーの実装**
```
  def autocomplete
    query = params[:q]
    shops = Shop.where("name LIKE ?", "%#{query}%").select(:name).distinct.limit(5)

    render json: shops.map { |shop| { id: nil, name: shop.name } }
  end
```

**ビューの編集**
`_search_form.html.erb`
Stimulusコントローラーで使用するtarget属性を追加。
`<ul data-autocomplete-target="results" class="absolute left-0 right-0 bg-white rounded-md shadow-lg mt-2 max-h-60 overflow-auto z-50"></ul>
`